### PR TITLE
Added Custom Price Method Override

### DIFF
--- a/src/mint/web3.js
+++ b/src/mint/web3.js
@@ -51,6 +51,9 @@ const getDefaultMintPrice = () => {
 }
 
 export const getMintPrice = async () => {
+    const customPriceMethod = getMethodWithCustomName('price');
+    if(customPriceMethod) return customPriceMethod();
+
     const matches = Object.keys(NFTContract.methods).filter(key =>
         !key.includes("()") && (key.toLowerCase().includes('price') || key.toLowerCase().includes('cost'))
     )


### PR DESCRIPTION
Added an override so users can override the name of the price function by adding a custom name in the settings, similarly to how this could be done with the mint function:
`      
contractMethods: {
         mint: "mintQueen",
         price: "getPriceQueen"
    }`
